### PR TITLE
 Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/dynamic_batching_test.py
+++ b/dynamic_batching_test.py
@@ -26,6 +26,11 @@ import dynamic_batching
 
 import tensorflow as tf
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 _SLEEP_TIME = 1.0
 

--- a/dynamic_batching_test.py
+++ b/dynamic_batching_test.py
@@ -26,10 +26,7 @@ import dynamic_batching
 
 import tensorflow as tf
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from six.moves import range
 
 
 _SLEEP_TIME = 1.0
@@ -87,7 +84,7 @@ class DynamicBatchingTest(tf.test.TestCase):
         return a + b
 
       outputs = []
-      for i in xrange(200):
+      for i in range(200):
         outputs.append(f(tf.fill([1, 5], i), tf.fill([1, 5], i)))
 
       tf.train.start_queue_runners()
@@ -412,7 +409,7 @@ class DynamicBatchingBenchmarks(tf.test.Benchmark):
         return a + b
 
       outputs = []
-      for _ in xrange(1000):
+      for _ in range(1000):
         outputs.append(f(tf.ones([1, 10]), tf.ones([1, 10])))
       op_to_benchmark = tf.group(*outputs)
 
@@ -432,7 +429,7 @@ class DynamicBatchingBenchmarks(tf.test.Benchmark):
         return a + b
 
       outputs = []
-      for _ in xrange(1000):
+      for _ in range(1000):
         outputs.append(f(tf.ones([1, 100000]), tf.ones([1, 100000])))
       op_to_benchmark = tf.group(*outputs)
 

--- a/experiment.py
+++ b/experiment.py
@@ -252,7 +252,7 @@ def build_actor(agent, env, level_name, action_set):
 
   def step(input_, unused_i):
     """Steps through the agent and the environment."""
-    (env_state, env_output, agent_state, agent_output) = input_
+    env_state, env_output, agent_state, agent_output = input_
 
     # Run agent.
     action = agent_output[0]
@@ -549,7 +549,7 @@ def train(action_set, level_names):
 
       def make_time_major(s):
         return nest.map_structure(
-            lambda t: tf.transpose(t, [1, 0] + range(t.shape.ndims)[2:]), s)
+            lambda t: tf.transpose(t, [1, 0] + list(range(t.shape.ndims))[2:]), s)
 
       dequeued = dequeued._replace(
           env_outputs=make_time_major(dequeued.env_outputs),

--- a/experiment.py
+++ b/experiment.py
@@ -140,8 +140,8 @@ class Agent(snt.RNNCore):
     # Return last output.
     return tf.reverse_sequence(output, length, seq_axis=1)[:, 0]
 
-  def _torso(self, last_action__env_output):
-    last_action, env_output = last_action__env_output
+  def _torso(self, input_):
+    last_action, env_output = input_
     reward, _, _, (frame, instruction) = env_output
 
     # Convert to floats.
@@ -197,8 +197,8 @@ class Agent(snt.RNNCore):
 
     return AgentOutput(new_action, policy_logits, baseline)
 
-  def _build(self, action__env_output, core_state):
-    (action, env_output) = action__env_output
+  def _build(self, input_, core_state):
+    action, env_output = input_
     actions, env_outputs = nest.map_structure(lambda t: tf.expand_dims(t, 0),
                                               (action, env_output))
     outputs, core_state = self.unroll(actions, env_outputs, core_state)

--- a/experiment.py
+++ b/experiment.py
@@ -37,10 +37,7 @@ try:
 except tf.errors.NotFoundError:
   tf.logging.warning('Running without dynamic batching.')
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from six.moves import range
 
 
 nest = tf.contrib.framework.nest
@@ -253,10 +250,9 @@ def build_actor(agent, env, level_name, action_set):
       create_state, (initial_env_state, initial_env_output, initial_agent_state,
                      initial_agent_output))
 
-  def step(env_state__env_output__agent_state__agent_output, unused_i):
+  def step(input_, unused_i):
     """Steps through the agent and the environment."""
-    (env_state, env_output, agent_state,
-     agent_output) = env_state__env_output__agent_state__agent_output
+    (env_state, env_output, agent_state, agent_output) = input_
 
     # Run agent.
     action = agent_output[0]
@@ -522,7 +518,7 @@ def train(action_set, level_names):
 
     # Build actors and ops to enqueue their output.
     enqueue_ops = []
-    for i in xrange(FLAGS.num_actors):
+    for i in range(FLAGS.num_actors):
       if is_actor_fn(i):
         level_name = level_names[i % len(level_names)]
         tf.logging.info('Creating actor %d with level %s', i, level_name)

--- a/py_process_test.py
+++ b/py_process_test.py
@@ -25,6 +25,11 @@ import numpy as np
 import py_process
 import tensorflow as tf
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class PyProcessTest(tf.test.TestCase):
 

--- a/py_process_test.py
+++ b/py_process_test.py
@@ -25,10 +25,7 @@ import numpy as np
 import py_process
 import tensorflow as tf
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from six.moves import range
 
 
 class PyProcessTest(tf.test.TestCase):
@@ -257,7 +254,7 @@ class PyProcessBenchmarks(tf.test.Benchmark):
   def benchmark_many(self):
     with tf.Graph().as_default():
       ps = [
-          py_process.PyProcess(PyProcessBenchmarks.Example) for _ in xrange(200)
+          py_process.PyProcess(PyProcessBenchmarks.Example) for _ in range(200)
       ]
       compute_ops = [p.proxy.compute(2) for p in ps]
       compute = tf.group(*compute_ops)


### PR DESCRIPTION
* __xrange()__ was removed in Python 3 in favor of __range()__.
* Python 3 does not allow explicit tuples as function parameters.