### PR TITLE
Docker build file to work with nvidia docker 2

### DIFF
--- a/Dockerfile.devel-gpu
+++ b/Dockerfile.devel-gpu
@@ -1,0 +1,81 @@
+FROM tensorflow/tensorflow:nightly-devel-gpu
+
+# Install dependencies.
+# g++ (v. 5.4) does not work: https://github.com/tensorflow/tensorflow/issues/13308
+#RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+#    apt-get update && apt install g++-7 -y && \
+#    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60  \
+#                        --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
+#    update-alternatives --config gcc
+
+RUN apt-get install -y \
+    lua5.1 \
+    liblua5.1-0-dev \
+    libffi-dev \
+    gettext \
+    freeglut3 \
+    libsdl2-dev \
+    libosmesa6-dev \
+    libglu1-mesa \
+    libglu1-mesa-dev \
+    libjpeg-dev
+
+# Install TensorFlow and other dependencies
+RUN pip install dm-sonnet
+
+RUN rm /etc/bazel*
+
+# Build and install DeepMind Lab pip package.
+# We explicitly set the Numpy path as shown here:
+# https://github.com/deepmind/lab/blob/master/docs/users/build.md
+RUN NP_INC="$(python -c 'import numpy as np; print(np.get_include())[5:]')" && \
+    git clone https://github.com/mengdong/lab.git && \
+    cd lab && \
+    sed -i 's@hdrs = glob(\[@hdrs = glob(["'"$NP_INC"'/\*\*/*.h", @g' python.BUILD && \
+    sed -i 's@includes = \[@includes = ["'"$NP_INC"'", @g' python.BUILD && \
+    bazel build -c opt python/pip_package:build_pip_package && \
+    pip install wheel && \
+    ./bazel-bin/python/pip_package/build_pip_package /tmp/dmlab_pkg && \
+    pip install /tmp/dmlab_pkg/DeepMind_Lab-1.0-py2-none-any.whl --force-reinstall
+
+# Install dataset (from https://github.com/deepmind/lab/tree/master/data/brady_konkle_oliva2008)
+RUN mkdir dataset && \
+    cd dataset && \
+    pip install Pillow && \
+    curl -sS https://raw.githubusercontent.com/deepmind/lab/master/data/brady_konkle_oliva2008/README.md | \
+    tr '\n' '\r' | \
+    sed -e 's/.*```sh\(.*\)```.*/\1/' | \
+    tr '\r' '\n' | \
+    bash
+
+# Clone.
+RUN git clone https://github.com/deepmind/scalable_agent.git
+WORKDIR scalable_agent
+
+# Build dynamic batching module
+# build dynamic batching inside the container with gcc-7 since tensorflow requires cuda and docker cannot build with cuda runtime
+# RUN TF_INC="$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')" && \
+#     TF_LIB="$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')" && \
+#     g++-7 -std=c++11 -shared batcher.cc -o batcher.so -fPIC -I $TF_INC -O2 -D_GLIBCXX_USE_CXX11_ABI=0 -L$TF_LIB -L$LD_LIBRARY_PATH -ltensorflow_framework
+
+# Run tests inside the container
+#RUN python py_process_test.py
+#RUN python dynamic_batching_test.py
+#RUN python vtrace_test.py
+
+# TensorBoard
+EXPOSE 6006
+# IPython
+EXPOSE 8888
+
+WORKDIR "/root"
+CMD ["/bin/bash"]
+
+
+# Run.
+# CMD ["sh", "-c", "python experiment.py --total_environment_frames=10000 --dataset_path=../dataset && python experiment.py --mode=test --test_num_episodes=5"]
+
+# Docker commands:
+#   docker rm scalable_agent -v
+#   docker build -t scalable_agent .
+#   docker run --name scalable_agent scalable_agent


### PR DESCRIPTION
This is a docker file to work with nvidia docker 2, based on tensorflow/tensorflow:nightly-devel-gpu. Changed gcc 4.8 to gcc 7 to avoid dynamic batching build problem (dynamic batching test hangs with gcc 4.8)